### PR TITLE
reset on resolution level change

### DIFF
--- a/bioio_base/reader.py
+++ b/bioio_base/reader.py
@@ -310,6 +310,9 @@ class Reader(ImageContainer, ABC):
             )
 
         self._current_resolution_level = resolution_level
+        # Reset self for future read
+        # Note that this resets metadata as well.
+        self._reset_self()
 
     @abstractmethod
     def _read_delayed(self) -> xr.DataArray:

--- a/bioio_base/reader.py
+++ b/bioio_base/reader.py
@@ -309,10 +309,11 @@ class Reader(ImageContainer, ABC):
                 "available besides the default of 0."
             )
 
-        self._current_resolution_level = resolution_level
-        # Reset self for future read
-        # Note that this resets metadata as well.
-        self._reset_self()
+        if resolution_level != self._current_resolution_level:
+            self._current_resolution_level = resolution_level
+            # Reset self for future read
+            # Note that this resets metadata as well.
+            self._reset_self()
 
     @abstractmethod
     def _read_delayed(self) -> xr.DataArray:


### PR DESCRIPTION
Fixes #15 by forcing a data reset when resolution level is changed (same as set_scene).

### Link to Relevant Issue

This pull request resolves #15
