### PR TITLE
Clearer error message if incorrect type is passed to get_image_dask_data

### DIFF
--- a/bioio_base/transforms.py
+++ b/bioio_base/transforms.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from collections import Counter
-from typing import Any, List, Literal, Optional, Tuple, Union
 from numbers import Integral
+from typing import Any, List, Literal, Optional, Tuple, Union
 
 import dask.array as da
 import numpy as np
@@ -240,7 +240,10 @@ def reshape_data(
 
                 # Check that integer
                 if not isinstance(dim_spec, Integral):
-                    raise TypeError(f"Dimensions not in output must be integers. Got {type(dim_spec).__name__} for {dim}.")
+                    raise TypeError(
+                        "Dimensions not in output must be integers. "
+                        f"Got {type(dim_spec).__name__} for {dim}."
+                    )
                 check_selection_max = dim_spec
             else:
                 dim_spec = 0


### PR DESCRIPTION
# Issue
I wrote some incorrect code that was a little hard to debug because the error message lacked detail.

Simplified example
```python
time = foo()  # returns 4
channel = bar()  # returns None
reader.get_image_dask_data("ZYX", T=time, C=channel)
```
The current error message: `TypeError: '>' not supported between instances of 'NoneType' and 'int'`

# Changes
* New error message says which dimension had an issue and makes clear that it is user error: `TypeError: Dimensions not in output must be integers. Got NoneType for C.`
* Code now does what the comment "Check that integer" suggests

# Implementation notes
We're checking against `Integral` instead of `int` because `Integral` is more general, including numpy integers, for example.

# Testing
I ran the following script. I didn't add a unit test because the error class (TypeError) remains the same.
```python
from bioio_base.transforms import reshape_data
import numpy as np

reshape_data(np.zeros(( 40, 40, 40, 40, 40 )), "CTZYX", "XYZ", T=np.int64(4), C=0)
reshape_data(np.zeros(( 40, 40, 40, 40, 40 )), "CTZYX", "XYZ", T=np.int64(4), C=None)
``` 