### PR TITLE
bugfix/resolution-level-dims-cacheing

### DIFF
--- a/bioio_base/reader.py
+++ b/bioio_base/reader.py
@@ -231,7 +231,7 @@ class Reader(ImageContainer, ABC):
         for level in self.resolution_levels:
             self.set_resolution_level(level)
             resolution_level_dims[level] = self.shape
-        self.set_resolution_level(initial_resoluiton_level)
+        self.set_resolution_level(initial_resolution_level)
 
         return resolution_level_dims
 

--- a/bioio_base/reader.py
+++ b/bioio_base/reader.py
@@ -225,7 +225,7 @@ class Reader(ImageContainer, ABC):
         resolution_level_dims: Dict[int, Tuple[int, ...]]
             resolution level dictionary of shapes.
         """
-        initial_resoluiton_level = self.current_resolution_level
+        initial_resolution_level = self.current_resolution_level
         resolution_level_dims = {}
 
         for level in self.resolution_levels:

--- a/bioio_base/reader.py
+++ b/bioio_base/reader.py
@@ -48,7 +48,6 @@ class Reader(ImageContainer, ABC):
     _scenes: Optional[Tuple[str, ...]] = None
     _current_scene_index: int = 0
     _current_resolution_level: int = 0
-    _resolution_level_dict: Optional[Dict[int, Tuple[int, ...]]] = None
     # Do not default because they aren't used by all readers
     _fs: AbstractFileSystem
     _path: str
@@ -226,17 +225,15 @@ class Reader(ImageContainer, ABC):
         resolution_level_dims: Dict[int, Tuple[int, ...]]
             resolution level dictionary of shapes.
         """
-        if self._resolution_level_dict is None:
-            initial_resoluiton_level = self.current_resolution_level
-            resolution_level_dict = {}
+        initial_resoluiton_level = self.current_resolution_level
+        resolution_level_dims = {}
 
-            for level in self.resolution_levels:
-                self.set_resolution_level(level)
-                resolution_level_dict[level] = self.shape
-            self._resolution_level_dict = resolution_level_dict
-            self.set_resolution_level(initial_resoluiton_level)
+        for level in self.resolution_levels:
+            self.set_resolution_level(level)
+            resolution_level_dims[level] = self.shape
+        self.set_resolution_level(initial_resoluiton_level)
 
-        return self._resolution_level_dict
+        return resolution_level_dims
 
     def _reset_self(self) -> None:
         # Reset the data stored in the Reader object
@@ -246,7 +243,6 @@ class Reader(ImageContainer, ABC):
         self._mosaic_xarray_data = None
         self._dims = None
         self._metadata = None
-        self._resolution_level_dict = None
 
     def set_scene(self, scene_id: Union[str, int]) -> None:
         """


### PR DESCRIPTION
## Description 
In the last release, we added a resolution_level_dims property. We also cached this value. However, caches are cleared when we set a new resolution level so this feature doesn't work correctly. This is a quick fix to remove caching 
