### PR TITLE
Add physical pixel size to cached properties

### DIFF
--- a/bioio_base/reader.py
+++ b/bioio_base/reader.py
@@ -45,6 +45,7 @@ class Reader(ImageContainer, ABC):
     _mosaic_xarray_data: Optional[xr.DataArray] = None
     _dims: Optional[Dimensions] = None
     _metadata: Optional[Any] = None
+    _physical_pixel_sizes: Optional[PhysicalPixelSizes] = None
     _scenes: Optional[Tuple[str, ...]] = None
     _current_scene_index: int = 0
     _current_resolution_level: int = 0
@@ -243,6 +244,7 @@ class Reader(ImageContainer, ABC):
         self._mosaic_xarray_data = None
         self._dims = None
         self._metadata = None
+        self._physical_pixel_sizes = None
 
     def set_scene(self, scene_id: Union[str, int]) -> None:
         """


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request is required to resolve https://github.com/bioio-devs/bioio-lif/issues/14 : The `physical_pixel_sizes` property was not being updated on scene changes for the LIF reader
Should be reviewed in tandem with https://github.com/bioio-devs/bioio-lif/pull/16

### Description of Changes

Adds `_physical_pixel_sizes` to the cached properties that are cleared when `_reset_self` is called.

Important note: different readers handle this property differently; [bioio_tifffile](https://github.com/bioio-devs/bioio-tifffile/blob/main/bioio_tifffile/reader.py) uses the exact same name for the property, so will be affected by the reset/cache, whereas [bioio_czi](https://github.com/bioio-devs/bioio-czi/blob/main/bioio_czi/reader.py) uses a differently named property (similar to how bioio_lif was) that will not register the reset. In both cases, the test suite & build still pass with this modification to bioio-base, but they may behave differently on `_reset_self` 

### Testing
Verified existing tests still pass, but did not add a new unit test since we don't currently have tests for `_reset_self`
