### PR TITLE
Remove expected_scale and expected_time_scale from tests

### DIFF
--- a/bioio_base/test_utilities.py
+++ b/bioio_base/test_utilities.py
@@ -66,8 +66,6 @@ def run_image_container_checks(
     expected_physical_pixel_sizes: Tuple[
         Optional[float], Optional[float], Optional[float]
     ],
-    expected_scale: Tuple[Optional[float]],
-    expected_time_interval: Tuple[Optional[float]],
     expected_metadata_type: Union[type, Tuple[Union[type, Tuple[Any, ...]], ...]],
     set_resolution_level: int = 0,
     expected_current_resolution_level: int = 0,
@@ -101,8 +99,6 @@ def run_image_container_checks(
     assert image_container.dims.shape == expected_shape
     assert image_container.channel_names == expected_channel_names
     assert image_container.physical_pixel_sizes == expected_physical_pixel_sizes
-    assert image_container.scale == expected_scale
-    assert image_container.time_interval == expected_time_interval
     assert isinstance(image_container.metadata, expected_metadata_type)
 
     # Read different chunks
@@ -171,8 +167,6 @@ def run_image_file_checks(
     expected_physical_pixel_sizes: Tuple[
         Optional[float], Optional[float], Optional[float]
     ],
-    expected_scale: Tuple[Optional[float]],
-    expected_time_interval: Tuple[Optional[float]],
     expected_metadata_type: Union[type, Tuple[Union[type, Tuple[Any, ...]], ...]],
     set_resolution_level: int = 0,
     expected_current_resolution_level: int = 0,
@@ -198,8 +192,6 @@ def run_image_file_checks(
         expected_dims_order=expected_dims_order,
         expected_channel_names=expected_channel_names,
         expected_physical_pixel_sizes=expected_physical_pixel_sizes,
-        expected_scale=expected_scale,
-        expected_time_interval=expected_time_interval,
         expected_metadata_type=expected_metadata_type,
     )
 


### PR DESCRIPTION
Undoing a breaking change that the readers haven't been updated to support yet.

This PR splits out one piece of #29. From the original PR:

> Previously I added time_interval and scale to the ImageContainer class, as part of this I added them to test utilities which actually breaks bioio tests. We haven't done a release so we haven't seen these failures. This PR removes scale and time_interval from the test suite to have our bioio tests pass with the newest version of bioio-base.
>
>    We can add these in the future if we decide but we would need to adjust the corrosponding tests in bioio to test for them / input values for these
