### PR TITLE
bugfix/reset-self-pixel-size

### DIFF
--- a/bioio_base/reader.py
+++ b/bioio_base/reader.py
@@ -244,7 +244,7 @@ class Reader(ImageContainer, ABC):
         self._mosaic_xarray_data = None
         self._dims = None
         self._metadata = None
-        self._physical_pixel_sizes = None
+        self._physical_pixel_sizes = PhysicalPixelSizes(None, None, None)
 
     def set_scene(self, scene_id: Union[str, int]) -> None:
         """


### PR DESCRIPTION
## Description 

Fixes a typing issue with reset self

In another PR we updated the self._reset_self() function of the base reader to include self._physical_pixel_size. This means that when we switch scenes we reset the self._reset_self() to Null. In bioio our test suite expects a null value for self._physical_pixel_size to be PhysicalPixelSizes(Null,Null,Null) so when we change scenes and try to assert the new value we have a mismatch (resetting sets it to Null but it expects PhysicalPixelSizes(Null,Null,Null)). This PR just sets the reset value to PhysicalPixelSizes(Null,Null,Null)).
We use the ArrayLikeReader for tests in Bioio. The ArrayLikeReader only sets self._physical_pixel_size on __init__ so we essentially do not support Physical Pixel Size (one of the passed parameters) since any scene change will set it to null no matter what the user passes.
