### PR TITLE
Test utilities allow arbitrary kwargs to reader

### DIFF
--- a/bioio_base/test_utilities.py
+++ b/bioio_base/test_utilities.py
@@ -171,9 +171,10 @@ def run_image_file_checks(
     set_resolution_level: int = 0,
     expected_current_resolution_level: int = 0,
     expected_resolution_levels: Tuple[int, ...] = (0,),
+    reader_kwargs: dict = dict(fs_kwargs=dict(anon=True)),
 ) -> ImageContainer:
     # Init container
-    image_container = ImageContainer(image, fs_kwargs=dict(anon=True))
+    image_container = ImageContainer(image, **reader_kwargs)
 
     # Check for file pointers
     check_local_file_not_open(image_container)
@@ -211,12 +212,13 @@ def run_multi_scene_image_read_checks(
     second_scene_shape: Tuple[int, ...],
     second_scene_dtype: np.dtype,
     allow_same_scene_data: bool = True,
+    reader_kwargs: dict = dict(fs_kwargs=dict(anon=True)),
 ) -> ImageContainer:
     """
     A suite of tests to ensure that data is reset when switching scenes.
     """
     # Read file
-    image_container = ImageContainer(image, fs_kwargs=dict(anon=True))
+    image_container = ImageContainer(image, **reader_kwargs)
 
     check_local_file_not_open(image_container)
     check_can_serialize_image_container(image_container)
@@ -279,13 +281,14 @@ def run_no_scene_name_image_read_checks(
     second_scene_id: Union[str, int],
     second_scene_dtype: np.dtype,
     allow_same_scene_data: bool = True,
+    reader_kwargs: dict = dict(fs_kwargs=dict(anon=True)),
 ) -> ImageContainer:
     """
     A suite of tests to check that scene names are auto-filled when not present, and
     scene switching is reflected in current_scene_index.
     """
     # Read file
-    image_container = ImageContainer(image, fs_kwargs=dict(anon=True))
+    image_container = ImageContainer(image, **reader_kwargs)
 
     check_local_file_not_open(image_container)
     check_can_serialize_image_container(image_container)


### PR DESCRIPTION
# Issue
Readers can be defined with arbitrary keyword arguments, and they might want to use them in tests, but it's currently not possible.

Specifically, upcoming `bioio-czi` features introduce a new keyword argument so users will write code like `BioImage('/foo.czi', use_aicspylibczi=True)`.

# Changes
In the test utilities, `run_image_file_checks` and friends now accept an optional argument, a dictionary of keyword args that will get passed in when creating the reader.

Instead of always defining `fs_kwargs`, it is is now provided by default but may be overridden.

# Testing
I wrote new bioio-czi tests that successfully pass the upcoming `use_aicspylibczi` parameter through `run_image_file_checks`. I did not explicitly test the identical changes to `run_multi_scene_image_read_checks` and `run_no_scene_name_image_read_checks`.