### PR TITLE
feature/PPS-Null-reset

### DIFF
--- a/bioio_base/reader.py
+++ b/bioio_base/reader.py
@@ -245,7 +245,7 @@ class Reader(ImageContainer, ABC):
         self._mosaic_xarray_data = None
         self._dims = None
         self._metadata = None
-        self._physical_pixel_sizes = PhysicalPixelSizes(None, None, None)
+        self._physical_pixel_sizes = None
 
     def set_scene(self, scene_id: Union[str, int]) -> None:
         """


### PR DESCRIPTION
### Description

Previously we added Physical Pixel Size to the _reset_self() function to ensure resets in between scene setting. In this situation we treated our null value as PhysicalPixelSize(None,None,None). This causes some issues with cached values that originally would check to see if PPS was None. We decided that it is better to have our true No Value be None instead of PhysicalPixelSize(None,None,None).