### PR TITLE
Improve versatility of benchmarks + Add unit-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,31 @@ jobs:
         with:
           python-version: "3.x"
       - run: pip install check-manifest && check-manifest
+
+  # Check linting, formating, types, etc.
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+    - uses: extractions/setup-just@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[lint]
+    - name: Lint
+      run: just lint
   
   # Check tests pass on multiple Python and OS combinations
   test:
     runs-on: ${{ matrix.os }}
+    needs: [lint]
     strategy:
       fail-fast: false
       matrix:
@@ -57,26 +78,6 @@ jobs:
       run: just test
     - name: Upload Codecov
       uses: codecov/codecov-action@v5
-
-  # Check linting, formating, types, etc.
-  lint:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11"
-    - uses: extractions/setup-just@v3
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Install Dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install .[lint]
-    - name: Lint
-      run: just lint
 
   # Publish to PyPI if test, lint, and manifest checks passed
   publish:

--- a/bioio_base/noop_reader.py
+++ b/bioio_base/noop_reader.py
@@ -5,6 +5,7 @@ import fsspec
 import numpy as np
 import xarray as xr
 
+from .constants import METADATA_UNPROCESSED
 from .dimensions import DEFAULT_DIMENSION_ORDER_LIST
 from .reader import Reader
 
@@ -38,10 +39,12 @@ class NoopReader(Reader):
         return xr.DataArray(
             data=da.from_array(self._mock_data[self.current_scene_index]),
             dims=DEFAULT_DIMENSION_ORDER_LIST,
+            attrs={METADATA_UNPROCESSED: {}},
         )
 
     def _read_immediate(self) -> xr.DataArray:
         return xr.DataArray(
             data=self._mock_data[self.current_scene_index],
             dims=DEFAULT_DIMENSION_ORDER_LIST,
+            attrs={METADATA_UNPROCESSED: {}},
         )

--- a/bioio_base/tests/test_benchmark.py
+++ b/bioio_base/tests/test_benchmark.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+import csv
+import pathlib
+
+import bioio_base.benchmark
+import bioio_base.noop_reader
+
+
+def test_benchmark_local_file() -> None:
+    # Arrange
+    temp_file = pathlib.Path("temp_file.txt")
+    try:
+        temp_file.write_text("This is a temporary file for testing purposes.")
+        bioio_base.benchmark.benchmark(bioio_base.noop_reader.NoopReader, [temp_file])
+
+        # Act
+        output_destination = pathlib.Path("output.csv")
+
+        # Assert: Run some simple asserts to check output exists
+        output_destination = pathlib.Path("output.csv")
+        assert output_destination.exists(), "Output file was not created"
+        assert output_destination.stat().st_size > 0, "Output file is empty"
+        with open(output_destination, "r") as csvfile:
+            csv_reader = csv.DictReader(csvfile)
+            first_test = next(csv_reader)
+            assert first_test["File Name"] == "temp_file.txt"
+            assert first_test["File Size"] == "46.0B"
+    finally:
+        temp_file.unlink(missing_ok=True)
+        bioio_base.benchmark.cleanup()
+
+
+def test_benchmark_s3_file() -> None:
+    try:
+        # Arrange
+        s3_file = "https://gettylargeimages.s3.amazonaws.com/00094701.jpg"
+
+        # Act
+        bioio_base.benchmark.benchmark(bioio_base.noop_reader.NoopReader, [s3_file])
+
+        # Assert: Run some simple asserts to check output exists
+        output_destination = pathlib.Path("output.csv")
+        assert output_destination.exists(), "Output file was not created"
+        assert output_destination.stat().st_size > 0, "Output file is empty"
+        with open(output_destination, "r") as csvfile:
+            csv_reader = csv.DictReader(csvfile)
+            first_test = next(csv_reader)
+            assert first_test["File Name"] == "00094701.jpg"
+            assert first_test["File Size"] == "26.9MiB"
+    finally:
+        bioio_base.benchmark.cleanup()

--- a/bioio_base/tests/test_benchmark.py
+++ b/bioio_base/tests/test_benchmark.py
@@ -30,13 +30,13 @@ def test_benchmark_local_file() -> None:
         bioio_base.benchmark.cleanup()
 
 
-def test_benchmark_s3_file() -> None:
+def test_benchmark_http_file() -> None:
     try:
         # Arrange
-        s3_file = "https://gettylargeimages.s3.amazonaws.com/00094701.jpg"
+        http_file = "https://gettylargeimages.s3.amazonaws.com/00094701.jpg"
 
         # Act
-        bioio_base.benchmark.benchmark(bioio_base.noop_reader.NoopReader, [s3_file])
+        bioio_base.benchmark.benchmark(bioio_base.noop_reader.NoopReader, [http_file])
 
         # Assert: Run some simple asserts to check output exists
         output_destination = pathlib.Path("output.csv")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,10 @@ test = [
   "pytest>=5.4.3",
   "pytest-cov>=2.9.0",
   "pytest-raises>=0.11",
+
+  # Necessary to test http files (like in test_benchmark)
+  "aiohttp",
+  "requests",
 ]
 docs = [
   # Sphinx + Doc Gen + Styling


### PR DESCRIPTION
While adding some benchmark tests to `bioio-ome-zarr` I realized it would be useful to control which files are tested and to make this compatible for S3 paths. Then while updating this I realized its weird this doesn't have any tests itself so I added those in too.