### PR TITLE
feature/reader-name

### DIFF
--- a/bioio_base/reader.py
+++ b/bioio_base/reader.py
@@ -52,7 +52,8 @@ class Reader(ImageContainer, ABC):
     -----
     * It is up to the implementer of the Reader to decide which types they would like to
     accept (certain readers may not support buffers for example).
-    * Please update the `NAME` field for subsequent Readers.
+    * Readers should implement their own NAME string for ease of debugging
+    and identification.
 
     """
 


### PR DESCRIPTION
## Description 

The purpose of this PR is to resolve #https://github.com/bioio-devs/bioio/issues/159 and allow users to access the name of the reader. This is specifically useful at the `BioImage` level where users can call `BioImage.reader.name` to see which reader was selected to read their file.