### PR TITLE
bugfix/malformed-ome-still-return-sm

### DIFF
--- a/bioio_base/reader.py
+++ b/bioio_base/reader.py
@@ -1169,10 +1169,10 @@ class Reader(ImageContainer, ABC):
                     metadata.objective = "40x Magnification"
                     return metadata
         """
-        # Attempt to get OME metadata; ignore if not implemented
+        # Attempt to get OME metadata; ignore if not implemented or malformed
         try:
             ome = self.ome_metadata
-        except NotImplementedError:
+        except Exception:
             ome = None
 
         # Retrieve the dimensions information from the reader.

--- a/bioio_base/reader.py
+++ b/bioio_base/reader.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Optional, Tuple, Union
@@ -33,6 +34,8 @@ from .types import (
 )
 
 ###############################################################################
+
+log = logging.getLogger(__name__)
 
 
 class Reader(ImageContainer, ABC):
@@ -1172,7 +1175,10 @@ class Reader(ImageContainer, ABC):
         # Attempt to get OME metadata; ignore if not implemented or malformed
         try:
             ome = self.ome_metadata
-        except Exception:
+        except NotImplementedError:
+            ome = None
+        except Exception as err:
+            log.warning(f"While trying to get OME metadata: {err}")
             ome = None
 
         # Retrieve the dimensions information from the reader.


### PR DESCRIPTION
## Description 

The purpose of this PR is to resolve https://github.com/bioio-devs/bioio/issues/176. For a malformed CZI the construction of a ome object fails, currently we only wrap an unsupported when constructing standard metadata. This PR moves that to all exceptions. This means that `standard_metadata` will always try the best with what it has.