### PR TITLE
add python version input parameter

### DIFF
--- a/.github/workflows/shared_test.yml
+++ b/.github/workflows/shared_test.yml
@@ -38,6 +38,11 @@ on:
         required: false
         default: false
         type: boolean
+      test_python_versions:
+        description: JSON array of Python versions for test matrix
+        required: false
+        default: '["3.10", "3.11", "3.12", "3.13"]'
+        type: string
 
 jobs:
   test:
@@ -45,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ${{ fromJSON(inputs.test_python_versions) }}
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
Missed that this parameter was needed for bioio-ome-zarr when I reduced the number of parameters.

### Link to Relevant Issue

[This pull request resolves #](https://github.com/bioio-devs/bioio-base/issues/55) 

### Description of Changes

Just add input parameter to specify the non-default python versions to use.
