### PR TITLE
Fix bugs and inefficiencies in Reader.standard_metadata

### DIFF
--- a/bioio_base/reader.py
+++ b/bioio_base/reader.py
@@ -1184,6 +1184,7 @@ class Reader(ImageContainer, ABC):
         # Retrieve the dimensions information from the reader.
         dims = self.dims
         image_size_t = getattr(dims, DimensionNames.Time, None)
+        pps = self.physical_pixel_sizes
 
         # Construct the StandardMetadata instance using the reader's attributes.
         metadata = StandardMetadata(
@@ -1194,9 +1195,9 @@ class Reader(ImageContainer, ABC):
             image_size_y=getattr(dims, DimensionNames.SpatialY, None),
             image_size_z=getattr(dims, DimensionNames.SpatialZ, None),
             timelapse=image_size_t is not None and image_size_t > 0,
-            pixel_size_x=self.physical_pixel_sizes.X,
-            pixel_size_y=self.physical_pixel_sizes.Y,
-            pixel_size_z=self.physical_pixel_sizes.Z,
+            pixel_size_x=pps.X,
+            pixel_size_y=pps.Y,
+            pixel_size_z=pps.Z,
             # OME-derived fields (None if no OME metadata)
             binning=binning(ome) if ome is not None else None,
             imaged_by=imaged_by(ome) if ome is not None else None,

--- a/bioio_base/reader.py
+++ b/bioio_base/reader.py
@@ -1194,7 +1194,7 @@ class Reader(ImageContainer, ABC):
             image_size_x=getattr(dims, DimensionNames.SpatialX, None),
             image_size_y=getattr(dims, DimensionNames.SpatialY, None),
             image_size_z=getattr(dims, DimensionNames.SpatialZ, None),
-            timelapse=image_size_t is not None and image_size_t > 0,
+            timelapse=image_size_t is not None and image_size_t > 1,
             pixel_size_x=pps.X,
             pixel_size_y=pps.Y,
             pixel_size_z=pps.Z,

--- a/bioio_base/reader.py
+++ b/bioio_base/reader.py
@@ -1204,7 +1204,7 @@ class Reader(ImageContainer, ABC):
             imaging_datetime=imaging_datetime(ome) if ome is not None else None,
             objective=objective(ome) if ome is not None else None,
             timelapse_interval=timelapse_interval(ome, self.current_scene_index)
-            if ome
+            if ome is not None
             else self.time_interval,
             total_time_duration=total_time_duration(ome, self.current_scene_index)
             if ome is not None

--- a/bioio_base/reader.py
+++ b/bioio_base/reader.py
@@ -1182,22 +1182,20 @@ class Reader(ImageContainer, ABC):
             ome = None
 
         # Retrieve the dimensions information from the reader.
-        dims = self.dims
-        image_size_t = getattr(dims, DimensionNames.Time, None)
-        pps = self.physical_pixel_sizes
+        image_size_t = getattr(self.dims, DimensionNames.Time, None)
 
         # Construct the StandardMetadata instance using the reader's attributes.
         metadata = StandardMetadata(
-            dimensions_present=dims.order,
-            image_size_c=getattr(dims, DimensionNames.Channel, None),
+            dimensions_present=self.dims.order,
+            image_size_c=getattr(self.dims, DimensionNames.Channel, None),
             image_size_t=image_size_t,
-            image_size_x=getattr(dims, DimensionNames.SpatialX, None),
-            image_size_y=getattr(dims, DimensionNames.SpatialY, None),
-            image_size_z=getattr(dims, DimensionNames.SpatialZ, None),
+            image_size_x=getattr(self.dims, DimensionNames.SpatialX, None),
+            image_size_y=getattr(self.dims, DimensionNames.SpatialY, None),
+            image_size_z=getattr(self.dims, DimensionNames.SpatialZ, None),
             timelapse=image_size_t is not None and image_size_t > 1,
-            pixel_size_x=pps.X,
-            pixel_size_y=pps.Y,
-            pixel_size_z=pps.Z,
+            pixel_size_x=self.physical_pixel_sizes.X,
+            pixel_size_y=self.physical_pixel_sizes.Y,
+            pixel_size_z=self.physical_pixel_sizes.Z,
             # OME-derived fields (None if no OME metadata)
             binning=binning(ome) if ome is not None else None,
             imaged_by=imaged_by(ome) if ome is not None else None,

--- a/bioio_base/reader.py
+++ b/bioio_base/reader.py
@@ -1182,16 +1182,17 @@ class Reader(ImageContainer, ABC):
             ome = None
 
         # Retrieve the dimensions information from the reader.
-        image_size_t = getattr(self.dims, DimensionNames.Time, None)
+        dims = self.dims
+        image_size_t = getattr(dims, DimensionNames.Time, None)
 
         # Construct the StandardMetadata instance using the reader's attributes.
         metadata = StandardMetadata(
-            dimensions_present=self.dims.order,
-            image_size_c=getattr(self.dims, DimensionNames.Channel, None),
+            dimensions_present=dims.order,
+            image_size_c=getattr(dims, DimensionNames.Channel, None),
             image_size_t=image_size_t,
-            image_size_x=getattr(self.dims, DimensionNames.SpatialX, None),
-            image_size_y=getattr(self.dims, DimensionNames.SpatialY, None),
-            image_size_z=getattr(self.dims, DimensionNames.SpatialZ, None),
+            image_size_x=getattr(dims, DimensionNames.SpatialX, None),
+            image_size_y=getattr(dims, DimensionNames.SpatialY, None),
+            image_size_z=getattr(dims, DimensionNames.SpatialZ, None),
             timelapse=image_size_t is not None and image_size_t > 0,
             pixel_size_x=self.physical_pixel_sizes.X,
             pixel_size_y=self.physical_pixel_sizes.Y,


### PR DESCRIPTION
## Summary

- Fix `timelapse` flag: a single timepoint (`T=1`) is not a timelapse; threshold changed from `> 0` to `> 1` (closes #62)
- Standardize `ome` None checks: align `timelapse_interval` to use `if ome is not None` to match `total_time_duration` (closes #63)

## Test plan

- [x] Verify `standard_metadata.timelapse` is `False` for images with `T=1` and `True` for `T>1`
- [x] Verify `standard_metadata` returns correct pixel sizes and dimension info
- [x] Verify `timelapse_interval` is populated from OME metadata when available and falls back to `time_interval` otherwise

🤖 Generated with [Claude Code](https://claude.com/claude-code)