### PR TITLE
Add `Dimensions.__contains__`

### DIFF
--- a/bioio_base/dimensions.py
+++ b/bioio_base/dimensions.py
@@ -158,14 +158,9 @@ class Dimensions:
             )
 
     def __contains__(self, key: Union[str, Sequence[str]]) -> bool:
-        if isinstance(key, str):
-            return key in self._dims_shape
-        elif isinstance(key, seq):
+        if isinstance(key, seq) and not isinstance(key, str):
             return all(k in self._dims_shape for k in key)
-        else:
-            raise TypeError(
-                f"Key must be a string or list of strings but got type {type(key)}"
-            )
+        return key in self._dims_shape
 
     def __setattr__(self, __name: str, __value: int) -> None:
         super().__setattr__(__name, __value)

--- a/bioio_base/dimensions.py
+++ b/bioio_base/dimensions.py
@@ -157,6 +157,16 @@ class Dimensions:
                 f"Key must be a string or list of strings but got type {type(key)}"
             )
 
+    def __contains__(self, key: Union[str, Sequence[str]]) -> bool:
+        if isinstance(key, str):
+            return key in self._dims_shape
+        elif isinstance(key, seq):
+            return all(k in self._dims_shape for k in key)
+        else:
+            raise TypeError(
+                f"Key must be a string or list of strings but got type {type(key)}"
+            )
+
     def __setattr__(self, __name: str, __value: int) -> None:
         super().__setattr__(__name, __value)
 


### PR DESCRIPTION
This allows straightforward checking of whether dimension `S` is present, since the interface of this class previously made this a bit clumsy.

<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #68.

### Description of Changes

Implement `Dimensions.__contains__`, with similar semantics as `__getitem__`: accept a `str` or `Sequence[str]` and return `True` if all dimensions are present.

The `isort`, `autoflake`, and `black` lint steps passed, but `flake8` and `mypy` fail both on current `main` and with my changes.