### PR TITLE
Feat/fast subslice reads

### DIFF
--- a/bioio_base/reader.py
+++ b/bioio_base/reader.py
@@ -727,6 +727,33 @@ class Reader(ImageContainer, ABC):
             **kwargs,
         )
 
+    def _read_indexed(self, given_dims: str, dim_specs: list) -> np.ndarray:
+        """
+        Return the native-order array with ``dim_specs`` applied.
+
+        This is the seam that lets ``get_image_data`` read only the requested
+        sub-region. The default implementation materializes the full image and
+        slices it; readers that can read sub-regions cheaply should override it.
+
+        The result MUST equal ``self.data[tuple(dim_specs)]`` — i.e. integer specs
+        drop their axis while slice/list specs keep theirs, and the remaining axes
+        stay in ``given_dims`` order.
+
+        Parameters
+        ----------
+        given_dims: str
+            The native dimension ordering of the image (``self.dims.order``).
+        dim_specs: list
+            One getitem operation per dimension in ``given_dims``, as produced by
+            ``transforms.compute_dim_specs``.
+
+        Returns
+        -------
+        data: np.ndarray
+            The indexed image data in native (reduced) dimension order.
+        """
+        return self.data[tuple(dim_specs)]
+
     def get_image_data(
         self, dimension_order_out: Optional[str] = None, **kwargs: Any
     ) -> np.ndarray:
@@ -789,20 +816,26 @@ class Reader(ImageContainer, ABC):
         -----
         * If a requested dimension is not present in the data the dimension is
           added with a depth of 1.
-        * This will preload the entire image before returning the requested data.
+        * Only the requested sub-region is read when the reader supports it (see
+          ``_read_indexed``); otherwise the full image is read then sliced.
 
         See `aicsimageio.transforms.reshape_data` for more details.
         """
-        # If no out orientation, simply return current data as dask array
+        # If no out orientation, simply return current data
         if dimension_order_out is None:
             return self.data
 
-        # Transform and return
-        return transforms.reshape_data(
-            data=self.data,
-            given_dims=self.dims.order,
-            return_dims=dimension_order_out,
+        # Compute the indexer (reads no pixels), let the reader materialize only
+        # the requested sub-region, then pad/transpose to the requested order.
+        dim_specs, new_dims = transforms.compute_dim_specs(
+            self.shape,
+            self.dims.order,
+            dimension_order_out,
             **kwargs,
+        )
+        indexed = self._read_indexed(self.dims.order, dim_specs)
+        return transforms.finalize_dims(
+            indexed, new_dims, self.dims.order, dimension_order_out
         )
 
     @property

--- a/bioio_base/reader.py
+++ b/bioio_base/reader.py
@@ -727,23 +727,21 @@ class Reader(ImageContainer, ABC):
             **kwargs,
         )
 
-    def _read_indexed(self, given_dims: str, dim_specs: list) -> np.ndarray:
+    def _read_indexed(
+        self, given_dims: str, dim_specs: List[types.DimSpec]
+    ) -> np.ndarray:
         """
         Return the native-order array with ``dim_specs`` applied.
 
-        This is the seam that lets ``get_image_data`` read only the requested
-        sub-region. The default implementation materializes the full image and
-        slices it; readers that can read sub-regions cheaply should override it.
-
-        The result MUST equal ``self.data[tuple(dim_specs)]`` — i.e. integer specs
-        drop their axis while slice/list specs keep theirs, and the remaining axes
-        stay in ``given_dims`` order.
+        This lets ``get_image_data`` read only the requested sub-region.
+        The default implementation materializes the full image and slices it;
+        readers that can read sub-regions cheaply should override it.
 
         Parameters
         ----------
         given_dims: str
             The native dimension ordering of the image (``self.dims.order``).
-        dim_specs: list
+        dim_specs: List[types.DimSpec]
             One getitem operation per dimension in ``given_dims``, as produced by
             ``transforms.compute_dim_specs``.
 

--- a/bioio_base/reader.py
+++ b/bioio_base/reader.py
@@ -733,9 +733,10 @@ class Reader(ImageContainer, ABC):
         """
         Return the native-order array with ``dim_specs`` applied.
 
-        This lets ``get_image_data`` read only the requested sub-region.
-        The default implementation materializes the full image and slices it;
-        readers that can read sub-regions cheaply should override it.
+        The default behavior here is to call ``self.data`` which can cause a
+        delayed-load of the whole image. Readers should override this function
+        in order to do more optimal finegrained data reads based on the
+        ``dim_specs``.
 
         Parameters
         ----------

--- a/bioio_base/tests/test_reader.py
+++ b/bioio_base/tests/test_reader.py
@@ -8,9 +8,7 @@ from bioio_base import noop_reader, transforms
 def test_get_image_data_matches_full_read_then_slice() -> None:
     # NoopReader exposes mock data with dims TCZYX (shape 4, 5, 6, 7, 8).
     reader = noop_reader.NoopReader("anything")
-    expected = transforms.reshape_data(
-        reader.data, reader.dims.order, "ZYX", T=0, C=1
-    )
+    expected = transforms.reshape_data(reader.data, reader.dims.order, "ZYX", T=0, C=1)
     actual = reader.get_image_data("ZYX", T=0, C=1)
     np.testing.assert_array_equal(actual, expected)
 

--- a/bioio_base/tests/test_reader.py
+++ b/bioio_base/tests/test_reader.py
@@ -1,24 +1,25 @@
-from __future__ import annotations
+from typing import Any, Dict
 
 import numpy as np
+import pytest
 
 from bioio_base import noop_reader, transforms
 
 
-def test_get_image_data_matches_full_read_then_slice() -> None:
-    # NoopReader exposes mock data with dims TCZYX (shape 4, 5, 6, 7, 8).
+# NoopReader exposes mock data with dims TCZYX (shape 4, 5, 6, 7, 8).
+@pytest.mark.parametrize(
+    "order, kwargs",
+    [
+        ("ZYX", {"T": 0, "C": 1}),
+        ("TCZYX", {"C": [0, 2], "Z": slice(0, 4, 2)}),
+    ],
+)
+def test_get_image_data_matches_full_read_then_slice(
+    order: str, kwargs: Dict[str, Any]
+) -> None:
     reader = noop_reader.NoopReader("anything")
-    expected = transforms.reshape_data(reader.data, reader.dims.order, "ZYX", T=0, C=1)
-    actual = reader.get_image_data("ZYX", T=0, C=1)
-    np.testing.assert_array_equal(actual, expected)
-
-
-def test_get_image_data_matches_full_read_then_slice_with_iterables() -> None:
-    reader = noop_reader.NoopReader("anything")
-    expected = transforms.reshape_data(
-        reader.data, reader.dims.order, "TCZYX", C=[0, 2], Z=slice(0, 4, 2)
-    )
-    actual = reader.get_image_data("TCZYX", C=[0, 2], Z=slice(0, 4, 2))
+    expected = transforms.reshape_data(reader.data, reader.dims.order, order, **kwargs)
+    actual = reader.get_image_data(order, **kwargs)
     np.testing.assert_array_equal(actual, expected)
 
 

--- a/bioio_base/tests/test_reader.py
+++ b/bioio_base/tests/test_reader.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import numpy as np
+
+from bioio_base import noop_reader, transforms
+
+
+def test_get_image_data_matches_full_read_then_slice() -> None:
+    # NoopReader exposes mock data with dims TCZYX (shape 4, 5, 6, 7, 8).
+    reader = noop_reader.NoopReader("anything")
+    expected = transforms.reshape_data(
+        reader.data, reader.dims.order, "ZYX", T=0, C=1
+    )
+    actual = reader.get_image_data("ZYX", T=0, C=1)
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_get_image_data_matches_full_read_then_slice_with_iterables() -> None:
+    reader = noop_reader.NoopReader("anything")
+    expected = transforms.reshape_data(
+        reader.data, reader.dims.order, "TCZYX", C=[0, 2], Z=slice(0, 4, 2)
+    )
+    actual = reader.get_image_data("TCZYX", C=[0, 2], Z=slice(0, 4, 2))
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_get_image_data_no_order_returns_full_data() -> None:
+    reader = noop_reader.NoopReader("anything")
+    np.testing.assert_array_equal(reader.get_image_data(), reader.data)
+
+
+def test_read_indexed_default_matches_getitem() -> None:
+    reader = noop_reader.NoopReader("anything")
+    specs, _ = transforms.compute_dim_specs(
+        reader.shape, reader.dims.order, "CZYX", T=1
+    )
+    np.testing.assert_array_equal(
+        reader._read_indexed(reader.dims.order, specs),
+        reader.data[tuple(specs)],
+    )

--- a/bioio_base/tests/test_transforms.py
+++ b/bioio_base/tests/test_transforms.py
@@ -522,29 +522,63 @@ def test_convert_list_to_slice(
     assert transforms.reduce_to_slice(list_to_test) == expected
 
 
-def test_compute_dim_specs_fixed_integer_drops_axis() -> None:
-    specs, new_dims = transforms.compute_dim_specs((10, 100, 100), "ZYX", "YX", Z=1)
-    # Z is fixed and not in return_dims -> integer spec, axis dropped from new_dims
-    assert specs == [1, slice(None, None, None), slice(None, None, None)]
-    assert new_dims == "YX"
+# slice(None, None, None) is the "select everything" spec for an untouched axis.
+_ALL = slice(None, None, None)
 
 
-def test_compute_dim_specs_slice_kept() -> None:
+@pytest.mark.parametrize(
+    "shape, given_dims, return_dims, kwargs, expected_specs, expected_new_dims",
+    [
+        # Fixed integer not in return_dims -> bare-int spec, axis dropped.
+        ((10, 100, 100), "ZYX", "YX", {"Z": 1}, [1, _ALL, _ALL], "YX"),
+        # Slice in return_dims is kept as-is, axis stays.
+        (
+            (10, 100, 100),
+            "ZYX",
+            "ZYX",
+            {"Z": slice(0, 4, 2)},
+            [slice(0, 4, 2), _ALL, _ALL],
+            "ZYX",
+        ),
+        # Evenly-spaced list collapses to an equivalent slice.
+        (
+            (6, 100, 100),
+            "CYX",
+            "CYX",
+            {"C": [0, 2, 4]},
+            [slice(0, 5, 2), _ALL, _ALL],
+            "CYX",
+        ),
+        # Unevenly-spaced list cannot reduce, so it is kept as a list.
+        ((6, 100, 100), "CYX", "CYX", {"C": [0, 3, 1]}, [[0, 3, 1], _ALL, _ALL], "CYX"),
+    ],
+    ids=[
+        "fixed_integer_drops_axis",
+        "slice_kept",
+        "list_reduced_to_slice",
+        "list_kept",
+    ],
+)
+def test_compute_dim_specs(
+    shape: Tuple[int, ...],
+    given_dims: str,
+    return_dims: str,
+    kwargs: Mapping[str, Any],
+    expected_specs: List[Any],
+    expected_new_dims: str,
+) -> None:
     specs, new_dims = transforms.compute_dim_specs(
-        (10, 100, 100), "ZYX", "ZYX", Z=slice(0, 4, 2)
+        shape, given_dims, return_dims, **kwargs
     )
-    assert specs == [
-        slice(0, 4, 2),
-        slice(None, None, None),
-        slice(None, None, None),
-    ]
-    assert new_dims == "ZYX"
+    assert specs == expected_specs
+    assert new_dims == expected_new_dims
 
 
 def test_finalize_dims_pads_and_transposes() -> None:
-    data = np.zeros((100, 100))  # YX after indexing
-    out = transforms.finalize_dims(data, "YX", "YX", "TYX")
-    assert out.shape == (1, 100, 100)
+    data = np.arange(12).reshape(3, 4)  # YX after indexing
+    out = transforms.finalize_dims(data, "YX", "YX", "TXY")
+    assert out.shape == (1, 4, 3)
+    np.testing.assert_array_equal(out[0], data.T)
 
 
 def test_reshape_data_still_matches_helpers() -> None:

--- a/bioio_base/tests/test_transforms.py
+++ b/bioio_base/tests/test_transforms.py
@@ -523,9 +523,7 @@ def test_convert_list_to_slice(
 
 
 def test_compute_dim_specs_fixed_integer_drops_axis() -> None:
-    specs, new_dims = transforms.compute_dim_specs(
-        (10, 100, 100), "ZYX", "YX", Z=1
-    )
+    specs, new_dims = transforms.compute_dim_specs((10, 100, 100), "ZYX", "YX", Z=1)
     # Z is fixed and not in return_dims -> integer spec, axis dropped from new_dims
     assert specs == [1, slice(None, None, None), slice(None, None, None)]
     assert new_dims == "YX"
@@ -553,7 +551,5 @@ def test_reshape_data_still_matches_helpers() -> None:
     data = np.random.rand(10, 100, 100)
     direct = transforms.reshape_data(data, "ZYX", "YX", Z=3)
     specs, new_dims = transforms.compute_dim_specs(data.shape, "ZYX", "YX", Z=3)
-    via_helpers = transforms.finalize_dims(
-        data[tuple(specs)], new_dims, "ZYX", "YX"
-    )
+    via_helpers = transforms.finalize_dims(data[tuple(specs)], new_dims, "ZYX", "YX")
     np.testing.assert_array_equal(direct, via_helpers)

--- a/bioio_base/tests/test_transforms.py
+++ b/bioio_base/tests/test_transforms.py
@@ -520,3 +520,40 @@ def test_convert_list_to_slice(
     list_to_test: Union[List, Tuple], expected: Union[int, List, slice, Tuple]
 ) -> None:
     assert transforms.reduce_to_slice(list_to_test) == expected
+
+
+def test_compute_dim_specs_fixed_integer_drops_axis() -> None:
+    specs, new_dims = transforms.compute_dim_specs(
+        (10, 100, 100), "ZYX", "YX", Z=1
+    )
+    # Z is fixed and not in return_dims -> integer spec, axis dropped from new_dims
+    assert specs == [1, slice(None, None, None), slice(None, None, None)]
+    assert new_dims == "YX"
+
+
+def test_compute_dim_specs_slice_kept() -> None:
+    specs, new_dims = transforms.compute_dim_specs(
+        (10, 100, 100), "ZYX", "ZYX", Z=slice(0, 4, 2)
+    )
+    assert specs == [
+        slice(0, 4, 2),
+        slice(None, None, None),
+        slice(None, None, None),
+    ]
+    assert new_dims == "ZYX"
+
+
+def test_finalize_dims_pads_and_transposes() -> None:
+    data = np.zeros((100, 100))  # YX after indexing
+    out = transforms.finalize_dims(data, "YX", "YX", "TYX")
+    assert out.shape == (1, 100, 100)
+
+
+def test_reshape_data_still_matches_helpers() -> None:
+    data = np.random.rand(10, 100, 100)
+    direct = transforms.reshape_data(data, "ZYX", "YX", Z=3)
+    specs, new_dims = transforms.compute_dim_specs(data.shape, "ZYX", "YX", Z=3)
+    via_helpers = transforms.finalize_dims(
+        data[tuple(specs)], new_dims, "ZYX", "YX"
+    )
+    np.testing.assert_array_equal(direct, via_helpers)

--- a/bioio_base/transforms.py
+++ b/bioio_base/transforms.py
@@ -203,8 +203,6 @@ def compute_dim_specs(
             )
 
         # All checks and operations passed, append dim operation to getitem ops.
-        # The branches above narrow dim_spec to an int, slice, or List[int], but
-        # that can't be proven statically through the reassignments, so cast.
         dim_specs.append(cast(types.DimSpec, dim_spec))
 
     return dim_specs, new_dims

--- a/bioio_base/transforms.py
+++ b/bioio_base/transforms.py
@@ -82,6 +82,175 @@ def transpose_to_dims(
     return data
 
 
+def compute_dim_specs(
+    shape: Tuple[int, ...], given_dims: str, return_dims: str, **kwargs: Any
+) -> Tuple[List[Any], str]:
+    """
+    Compute the per-dimension getitem spec and the resulting dim string.
+
+    This is the indexer-building half of ``reshape_data``: it turns the kwargs
+    selection into a list of getitem operations (one per dimension in
+    ``given_dims``) plus the dimension string that results after the getitem.
+
+    Integer specs (a dimension fixed to one index and NOT present in
+    ``return_dims``) drop their axis under numpy/dask getitem; slice/list specs
+    keep their axis. Reading no pixels, this can be computed from ``shape`` alone.
+
+    Parameters
+    ----------
+    shape: Tuple[int, ...]
+        The shape of the data the specs will be applied to.
+    given_dims: str
+        The dimension ordering of the data, "CZYX", "VBTCXZY" etc.
+    return_dims: str
+        The dimension ordering of the return data.
+    kwargs: Any
+        Per-dimension selections (see ``reshape_data``).
+
+    Returns
+    -------
+    dim_specs: List[Any]
+        One getitem operation per dimension in ``given_dims``.
+    new_dims: str
+        The dimension ordering after applying ``dim_specs`` (integer-selected,
+        non-return dimensions removed).
+    """
+    # Check for parameter conflicts
+    for dim in given_dims:
+        # return_dims='CZYX' and iterable dimensions 'T=range(10)'
+        # Dimension is in kwargs
+        # Dimension is an iterable
+        # Dimension is not in return dimensions
+        if (
+            isinstance(kwargs.get(dim), (list, tuple, range, slice))
+            and dim not in return_dims
+        ):
+            raise ConflictingArgumentsError(
+                f"When selecting a multiple dimension indices, the specified "
+                f"dimension must be provided in return_dims. "
+                f"return_dims={return_dims}, dimension {dim} = {kwargs.get(dim)}"
+            )
+
+    # Process each dimension available
+    new_dims = given_dims
+    dim_specs: List[Any] = []
+    for dim in given_dims:
+        # Store index of the dim as it is in given data
+        dim_index = given_dims.index(dim)
+
+        # Handle dim in return_dims which means that it is
+        # an iterable or None selection
+        if dim in return_dims:
+            # Specific iterable requested
+            if dim in kwargs:
+                # Actual dim specification
+                # The specification provided for this dimension in the kwargs
+                dim_spec = kwargs.get(dim)
+                display_dim_spec = dim_spec
+
+                if isinstance(dim_spec, int):
+                    dim_spec = slice(dim_spec, dim_spec + 1)
+
+                # Convert operator to standard list or slice
+                # dask.Array and numpy.ndarray both natively support
+                # List[int] and slices being passed to getitem so no need to cast them
+                # to anything different
+                if isinstance(dim_spec, (tuple, range)):
+                    dim_spec = list(dim_spec)
+
+                # Get the largest absolute value index in the list using min and max
+                if isinstance(dim_spec, list):
+                    check_selection_max = max([abs(min(dim_spec)), max(dim_spec)])
+                    # try to convert to slice if possible
+                    dim_spec = reduce_to_slice(dim_spec)
+
+                # Get the largest absolute value index from start and stop of slice
+                if isinstance(dim_spec, slice):
+                    check_selection_max = max([abs(dim_spec.stop), abs(dim_spec.start)])
+            else:
+                # Nothing was requested from this dimension
+                dim_spec = slice(None, None, None)
+                display_dim_spec = dim_spec
+
+                # No op means that it doesn't matter how much data is in this dimension
+                check_selection_max = 0
+
+        # Not in return_dims means that it is a fixed integer selection
+        else:
+            if dim in kwargs:
+                # Integer requested
+                dim_spec = kwargs.get(dim)
+                display_dim_spec = dim_spec
+
+                # Check that integer
+                if not isinstance(dim_spec, Integral):
+                    raise TypeError(
+                        "Dimensions not in output must be integers. "
+                        f"Got {type(dim_spec).__name__} for {dim}."
+                    )
+                check_selection_max = dim_spec
+            else:
+                dim_spec = 0
+                display_dim_spec = dim_spec
+                check_selection_max = 0
+
+            # Remove dim from new dims as it is fixed size
+            new_dims = new_dims.replace(dim, "")
+
+        # Check that fixed integer request isn't outside of request
+        if check_selection_max > shape[dim_index]:
+            raise IndexError(
+                f"Dimension specified with {dim}={display_dim_spec} "
+                f"but Dimension shape is {shape[dim_index]}."
+            )
+
+        # All checks and operations passed, append dim operation to getitem ops
+        dim_specs.append(dim_spec)
+
+    return dim_specs, new_dims
+
+
+def finalize_dims(
+    data: types.ArrayLike, new_dims: str, given_dims: str, return_dims: str
+) -> types.ArrayLike:
+    """
+    Pad missing return dimensions with depth-1 axes, then transpose to
+    ``return_dims``.
+
+    This is the reshape/transpose half of ``reshape_data``, applied after a
+    getitem has already selected the requested data.
+
+    Parameters
+    ----------
+    data: types.ArrayLike
+        The already-indexed data (in ``new_dims`` order).
+    new_dims: str
+        The dimension ordering of ``data`` (the output of ``compute_dim_specs``).
+    given_dims: str
+        The original dimension ordering, used to detect which return dimensions
+        were not present in the source data and must be padded in.
+    return_dims: str
+        The desired output dimension ordering.
+
+    Returns
+    -------
+    data: types.ArrayLike
+        The data with the specified dimension ordering.
+    """
+    # Add empty dims where dimensions were requested but data doesn't exist
+    # Add dimensions to new dims where empty dims are added
+    for i, dim in enumerate(return_dims):
+        # This dimension wasn't processed
+        if dim not in given_dims:
+            new_dims = f"{new_dims[:i]}{dim}{new_dims[i:]}"
+            data = data.reshape(*data.shape[:i], 1, *data.shape[i:])
+
+    # Any extra dimensions have been removed, only a problem if the depth is > 1
+    return transpose_to_dims(
+        data, given_dims=new_dims, return_dims=return_dims
+    )  # don't pass kwargs or 2 copies
+
+
 def reshape_data(
     data: types.ArrayLike, given_dims: str, return_dims: str, **kwargs: Any
 ) -> types.ArrayLike:
@@ -171,113 +340,12 @@ def reshape_data(
     >>> data = np.random.rand((10, 100, 100))
     ... example = reshape_data(data, "CYX", "BSTCZYX", C=slice(0, -1, 3))
     """
-    # Check for parameter conflicts
-    for dim in given_dims:
-        # return_dims='CZYX' and iterable dimensions 'T=range(10)'
-        # Dimension is in kwargs
-        # Dimension is an iterable
-        # Dimension is not in return dimensions
-        if (
-            isinstance(kwargs.get(dim), (list, tuple, range, slice))
-            and dim not in return_dims
-        ):
-            raise ConflictingArgumentsError(
-                f"When selecting a multiple dimension indices, the specified "
-                f"dimension must be provided in return_dims. "
-                f"return_dims={return_dims}, dimension {dim} = {kwargs.get(dim)}"
-            )
-
-    # Process each dimension available
-    new_dims = given_dims
-    dim_specs = []
-    for dim in given_dims:
-        # Store index of the dim as it is in given data
-        dim_index = given_dims.index(dim)
-
-        # Handle dim in return_dims which means that it is
-        # an iterable or None selection
-        if dim in return_dims:
-            # Specific iterable requested
-            if dim in kwargs:
-                # Actual dim specification
-                # The specification provided for this dimension in the kwargs
-                dim_spec = kwargs.get(dim)
-                display_dim_spec = dim_spec
-
-                if isinstance(dim_spec, int):
-                    dim_spec = slice(dim_spec, dim_spec + 1)
-
-                # Convert operator to standard list or slice
-                # dask.Array and numpy.ndarray both natively support
-                # List[int] and slices being passed to getitem so no need to cast them
-                # to anything different
-                if isinstance(dim_spec, (tuple, range)):
-                    dim_spec = list(dim_spec)
-
-                # Get the largest absolute value index in the list using min and max
-                if isinstance(dim_spec, list):
-                    check_selection_max = max([abs(min(dim_spec)), max(dim_spec)])
-                    # try to convert to slice if possible
-                    dim_spec = reduce_to_slice(dim_spec)
-
-                # Get the largest absolute value index from start and stop of slice
-                if isinstance(dim_spec, slice):
-                    check_selection_max = max([abs(dim_spec.stop), abs(dim_spec.start)])
-            else:
-                # Nothing was requested from this dimension
-                dim_spec = slice(None, None, None)
-                display_dim_spec = dim_spec
-
-                # No op means that it doesn't matter how much data is in this dimension
-                check_selection_max = 0
-
-        # Not in return_dims means that it is a fixed integer selection
-        else:
-            if dim in kwargs:
-                # Integer requested
-                dim_spec = kwargs.get(dim)
-                display_dim_spec = dim_spec
-
-                # Check that integer
-                if not isinstance(dim_spec, Integral):
-                    raise TypeError(
-                        "Dimensions not in output must be integers. "
-                        f"Got {type(dim_spec).__name__} for {dim}."
-                    )
-                check_selection_max = dim_spec
-            else:
-                dim_spec = 0
-                display_dim_spec = dim_spec
-                check_selection_max = 0
-
-            # Remove dim from new dims as it is fixed size
-            new_dims = new_dims.replace(dim, "")
-
-        # Check that fixed integer request isn't outside of request
-        if check_selection_max > data.shape[dim_index]:
-            raise IndexError(
-                f"Dimension specified with {dim}={display_dim_spec} "
-                f"but Dimension shape is {data.shape[dim_index]}."
-            )
-
-        # All checks and operations passed, append dim operation to getitem ops
-        dim_specs.append(dim_spec)
-
-    # Run getitems
+    # Compute the per-dimension getitem ops, run them, then pad/transpose.
+    dim_specs, new_dims = compute_dim_specs(
+        data.shape, given_dims, return_dims, **kwargs
+    )
     data = data[tuple(dim_specs)]
-
-    # Add empty dims where dimensions were requested but data doesn't exist
-    # Add dimensions to new dims where empty dims are added
-    for i, dim in enumerate(return_dims):
-        # This dimension wasn't processed
-        if dim not in given_dims:
-            new_dims = f"{new_dims[:i]}{dim}{new_dims[i:]}"
-            data = data.reshape(*data.shape[:i], 1, *data.shape[i:])
-
-    # Any extra dimensions have been removed, only a problem if the depth is > 1
-    return transpose_to_dims(
-        data, given_dims=new_dims, return_dims=return_dims
-    )  # don't pass kwargs or 2 copies
+    return finalize_dims(data, new_dims, given_dims, return_dims)
 
 
 def generate_stack(

--- a/bioio_base/transforms.py
+++ b/bioio_base/transforms.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import annotations
 
 from collections import Counter
 from numbers import Integral
-from typing import Any, List, Literal, Optional, Tuple, Union
+from typing import List, Literal, Optional, Tuple, Union, cast
 
 import dask.array as da
 import numpy as np
@@ -83,8 +82,11 @@ def transpose_to_dims(
 
 
 def compute_dim_specs(
-    shape: Tuple[int, ...], given_dims: str, return_dims: str, **kwargs: Any
-) -> Tuple[List[Any], str]:
+    shape: Tuple[int, ...],
+    given_dims: str,
+    return_dims: str,
+    **kwargs: types.DimSelection,
+) -> Tuple[List[types.DimSpec], str]:
     """
     Compute the per-dimension getitem spec and the resulting dim string.
 
@@ -92,24 +94,20 @@ def compute_dim_specs(
     selection into a list of getitem operations (one per dimension in
     ``given_dims``) plus the dimension string that results after the getitem.
 
-    Integer specs (a dimension fixed to one index and NOT present in
-    ``return_dims``) drop their axis under numpy/dask getitem; slice/list specs
-    keep their axis. Reading no pixels, this can be computed from ``shape`` alone.
-
     Parameters
     ----------
     shape: Tuple[int, ...]
         The shape of the data the specs will be applied to.
     given_dims: str
-        The dimension ordering of the data, "CZYX", "VBTCXZY" etc.
+        The dimension ordering of the data, "CZYX", "MSTCZYX" etc.
     return_dims: str
         The dimension ordering of the return data.
-    kwargs: Any
+    kwargs: types.DimSelection
         Per-dimension selections (see ``reshape_data``).
 
     Returns
     -------
-    dim_specs: List[Any]
+    dim_specs: List[types.DimSpec]
         One getitem operation per dimension in ``given_dims``.
     new_dims: str
         The dimension ordering after applying ``dim_specs`` (integer-selected,
@@ -133,7 +131,7 @@ def compute_dim_specs(
 
     # Process each dimension available
     new_dims = given_dims
-    dim_specs: List[Any] = []
+    dim_specs: List[types.DimSpec] = []
     for dim in given_dims:
         # Store index of the dim as it is in given data
         dim_index = given_dims.index(dim)
@@ -204,8 +202,10 @@ def compute_dim_specs(
                 f"but Dimension shape is {shape[dim_index]}."
             )
 
-        # All checks and operations passed, append dim operation to getitem ops
-        dim_specs.append(dim_spec)
+        # All checks and operations passed, append dim operation to getitem ops.
+        # The branches above narrow dim_spec to an int, slice, or List[int], but
+        # that can't be proven statically through the reassignments, so cast.
+        dim_specs.append(cast(types.DimSpec, dim_spec))
 
     return dim_specs, new_dims
 
@@ -252,7 +252,10 @@ def finalize_dims(
 
 
 def reshape_data(
-    data: types.ArrayLike, given_dims: str, return_dims: str, **kwargs: Any
+    data: types.ArrayLike,
+    given_dims: str,
+    return_dims: str,
+    **kwargs: types.DimSelection,
 ) -> types.ArrayLike:
     """
     Reshape the data into return_dims, pad missing dimensions, and prune extra

--- a/bioio_base/types.py
+++ b/bioio_base/types.py
@@ -3,7 +3,7 @@
 
 from datetime import timedelta
 from pathlib import Path
-from typing import List, NamedTuple, Optional, TypeAlias, Union
+from typing import List, NamedTuple, Optional, Tuple, TypeAlias, Union
 
 import dask.array as da
 import numpy as np
@@ -25,6 +25,12 @@ ImageLike = Union[
     List[MetaArrayLike],
     List[PathLike],
 ]
+
+# A per-dimension selection (e.g. C=1, C=[0, 2], Z=slice(0, 4, 2)).
+DimSelection: TypeAlias = Union[int, List[int], Tuple[int, ...], range, slice]
+
+# A single getitem op applied to one dimension, as produced by compute_dim_specs.
+DimSpec: TypeAlias = Union[int, slice, List[int]]
 
 # Public type aliases for units
 UnitRegistry: TypeAlias = pint.UnitRegistry


### PR DESCRIPTION
## Summary

Previously `get_image_data` called `reshape_data(self.data, ...)`, which loaded the entire image before discarding everything outside the requested indices. This PR introduces a `_read_indexed` seam that receives the per-dimension getitem spec, so a reader that can read sub-regions cheaply can override it and skip the full read.

## What changed

**`reshape_data` split into two halves** (`transforms.py`), with `reshape_data` retained as a thin wrapper so existing callers are unaffected:
- `compute_dim_specs(shape, given_dims, return_dims, **kwargs)` — the indexer-building half. Turns the kwargs selection into one getitem op per dimension plus the resulting dim order.
- `finalize_dims(data, new_dims, given_dims, return_dims)` — the reshape/transpose half. Pads missing return dims with depth-1 axes and transposes to the requested order.

**`_read_indexed` seam** (`reader.py`):
- New `Reader._read_indexed(given_dims, dim_specs) -> np.ndarray`. The default implementation is `self.data[tuple(dim_specs)]` (full read + slice), so behavior is unchanged for every existing reader.
- Readers that support cheap sub-region reads override this method.
- `get_image_data` now runs `compute_dim_specs` → `_read_indexed` → `finalize_dims`.

**Typed dim selections/specs** (`types.py`):
- `DimSelection = Union[int, List[int], Tuple[int, ...], range, slice]` — a caller's per-dimension selection.
- `DimSpec = Union[int, slice, List[int]]` — the normalized getitem op produced by `compute_dim_specs`.
